### PR TITLE
Dynamically link libcurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ example: SMEMBERS btc:mk:pow
 
 **Operating system**
 
-Ubuntu 16.04 or Ubuntu 18.04 or Ubuntu 20.04. Not yet tested on other systems.
+Ubuntu 16.04 or Ubuntu 18.04 or Ubuntu 20.04 or Debian 10. Not yet tested on other systems.
 
 **Requirements**
 

--- a/bitpeer/makefile
+++ b/bitpeer/makefile
@@ -1,4 +1,4 @@
 TARGET  := bitpeer.exe
 INCS = -I ../network -I ../utils
-LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lcurl -lssl -lcrypto -Wl,-Bdynamic -ldl -lm -lpthread -lz
+LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lssl -lcrypto -Wl,-Bdynamic -lcurl -ldl -lm -lpthread -lz
 include ../makefile.inc

--- a/blockmaster/makefile
+++ b/blockmaster/makefile
@@ -1,4 +1,4 @@
 TARGET  := blockmaster.exe
 INCS = -I ../network -I ../utils
-LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lcurl -lssl -lcrypto -Wl,-Bdynamic -ldl -lm -lpthread -lz
+LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lssl -lcrypto -Wl,-Bdynamic -lcurl -ldl -lm -lpthread -lz
 include ../makefile.inc

--- a/jobmaster/makefile
+++ b/jobmaster/makefile
@@ -1,4 +1,4 @@
 TARGET  := jobmaster.exe
 INCS = -I ../network -I ../utils
-LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lcurl -lssl -lcrypto -Wl,-Bdynamic -ldl -lm -lpthread -lz
+LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lssl -lcrypto -Wl,-Bdynamic -lcurl -ldl -lm -lpthread -lz
 include ../makefile.inc

--- a/mineragent/makefile
+++ b/mineragent/makefile
@@ -1,4 +1,4 @@
 TARGET  := mineragent.exe
 INCS = -I ../network -I ../utils
-LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lcurl -lssl -lcrypto -Wl,-Bdynamic -lm
+LIBS = -L ../utils -lutils -L ../network -lnetwork -Wl,-Bstatic -lev -lhiredis -ljansson -lssl -lcrypto -Wl,-Bdynamic -lcurl -lm
 include ../makefile.inc


### PR DESCRIPTION
Statically linking curl can be problematic on some platforms, as it may link against a bunch of other libraries that are not required for the mining pool software. This link illustrates more of the issue in general: https://stackoverflow.com/questions/7279764/static-linking-libcurl-using-c

This patch moves libcurl to be dynamically linked so the associated binaries can be built on Debian 10 (Buster) without pulling in additional dependencies.