### PR TITLE
Add a flag to optionally disable the segwit commitment

### DIFF
--- a/jobmaster/jm_config.c
+++ b/jobmaster/jm_config.c
@@ -271,6 +271,11 @@ int do_load_config(json_t *root)
         printf("load http svr config fail: %d\n", ret);
         return -__LINE__;
     }
+    ret = read_cfg_bool(root, "segwit_commitment", &settings.segwit_commitment_enabled, false, true);
+    if (ret < 0) {
+        printf("read segwit_commitment fail: %d\n", ret);
+        return -__LINE__;
+    }
 
     return 0;
 }

--- a/jobmaster/jm_config.h
+++ b/jobmaster/jm_config.h
@@ -67,6 +67,7 @@ struct settings {
     bool                coinbase_account;
     int                 spv_mining_timeout;
     http_svr_cfg        http_svr;
+    bool                segwit_commitment_enabled;
 };
 
 extern struct settings settings;


### PR DESCRIPTION
Some nodes, like Bitcoin ABC do not provide `default_witness_commitment` in `getblocktemplate` since segwit is not supported. This patch provides an easy way to disable the assumption that a segwit commitment will always be provided. It remains enabled by default in order to be compatible with configurations in the wild.

I tested this patch with `segwit_commitment` both enabled and disabled with Bitcoin ABC. Enabled fails as expected and disabled can be used to mine blocks on testnet as expected.

Given that there is no test coverage for any of the pool software, I highly recommend testing this on BTC and other coins before merging.