### PR TITLE
Add support for p2sh coinbase outputs

### DIFF
--- a/jobmaster/jm_config.c
+++ b/jobmaster/jm_config.c
@@ -36,7 +36,7 @@ int read_vcashcoin(json_t *root, const char *key)
     return load_cfg_coin_rpc_sub(vcash_obj, settings.vcash_coin);
 }
 
-int read_recipient(json_t *root, const char *key, sds *recipient)
+int read_recipient(json_t *root, const char *key, sds *recipient, enum address_type *addr_type)
 {
     char *address;
     int ret = read_cfg_str(root, key, &address, NULL);
@@ -44,7 +44,7 @@ int read_recipient(json_t *root, const char *key, sds *recipient)
         printf("read: %s fail: %d\n", key ,ret);
         return -__LINE__;
     }
-    *recipient = address2sig(address);
+    *recipient = address2sig(address, addr_type);
     if (*recipient == NULL) {
         printf("key: %s, invalid address: %s\n", key, address);
         return -__LINE__;
@@ -76,7 +76,7 @@ int read_recipients(json_t *root, const char *key)
         if(!json_is_real(percent_object))
             return -__LINE__;
 
-        sds address = address2sig(json_string_value(address_object));
+        sds address = address2sig(json_string_value(address_object), &settings.coin_recipients[i].addr_type);
         if(address == NULL)
             return -__LINE__;
         double percent = json_real_value(percent_object);
@@ -181,7 +181,7 @@ int do_load_config(json_t *root)
         printf("load main_coin config fail: %d\n", ret);
         return -__LINE__;
     }
-    ret = read_recipient(root, "main_coin_recipient", &settings.main_coin_recipient);
+    ret = read_recipient(root, "main_coin_recipient", &settings.main_coin_recipient, &settings.main_coin_recipient_addr_type);
     if (ret < 0) {
         printf("read main_coin_recipient fail: %d\n", ret);
         return -__LINE__;

--- a/jobmaster/jm_config.h
+++ b/jobmaster/jm_config.h
@@ -17,6 +17,7 @@
 # include "nw_clt.h"
 # include "nw_timer.h"
 # include "nw_state.h"
+# include "ut_base58.h"
 # include "ut_log.h"
 # include "ut_sds.h"
 # include "ut_cli.h"
@@ -29,6 +30,7 @@
 
 struct coin_recipient {
     sds address;
+    enum address_type addr_type;
     double percent;
 };
 
@@ -47,6 +49,7 @@ struct settings {
 
     coin_rpc_cfg        main_coin;
     sds                 main_coin_recipient;
+    enum address_type   main_coin_recipient_addr_type;
     struct coin_recipient *coin_recipients;
     int                 coin_recipient_count;
     double              coin_recipient_percents;

--- a/utils/ut_base58.c
+++ b/utils/ut_base58.c
@@ -124,7 +124,7 @@ sds base58_encode(const char *mem, size_t len)
     return result;
 }
 
-sds address2sig(const char *address)
+sds address2sig(const char *address, enum address_type *addr_type_out)
 {
     sds r = base58_decode(address);
 
@@ -137,6 +137,15 @@ sds address2sig(const char *address)
         return NULL;
     }
     sds result = sdsnewlen(r + 1, sdslen(r) - 5);
+
+    unsigned char version = r[0];
+    // check for testnet (0xc4) and mainnet (0x05) p2sh addresses
+    if (version == 0xc4 || version == 0x05) {
+        *addr_type_out = address_type_p2sh;
+    } else {
+        *addr_type_out = address_type_p2pkh;
+    }
+
     sdsfree(r);
     return result;
 }

--- a/utils/ut_base58.h
+++ b/utils/ut_base58.h
@@ -11,10 +11,15 @@
 
 # include "ut_sds.h"
 
+enum address_type {
+  address_type_p2pkh,
+  address_type_p2sh,
+};
+
 sds base58_decode(const char *str);
 sds base58_encode(const char *mem, size_t len);
 
-sds address2sig(const char *address);
+sds address2sig(const char *address, enum address_type *addr_type_out);
 sds sig2address(uint8_t version, const char *sig);
 
 sds zec_address2sig(const char *address);


### PR DESCRIPTION
This adds support for p2sh addresses as coinbase recipients.

I tested this patch mining on ABC testnet so as to adhere to the 8% miner fund coinbase rule. In my testing, I configured the miner fund address as both `main_coin_recipient` and as a `coin_recipient` and they both work as expected. P2PKH was also tested for regressions.

Although I'm unable to mine on mainnet, I also tested that jobmaster outputs valid coinbase outputs in its logs.

Since there is no test coverage in the pool software, I highly recommend testing this on BTC and other coins before merging.